### PR TITLE
Carousel - Correct offset calculation

### DIFF
--- a/jquery.cycle2.carousel.js
+++ b/jquery.cycle2.carousel.js
@@ -236,7 +236,7 @@ $.fn.cycle.transitions.carousel = {
         // returns callback fn that resets the left/top wrap position to the "real" slides
         return function() {
             var pos = $(opts.slides[opts.nextSlide]).position();
-            var offset = 0 - pos[vert?'top':'left'] - (opts.carouselOffset || 0);
+            var offset = 0 - pos[vert?'top':'left'] + (opts.carouselOffset || 0);
             opts._carouselWrap.css( opts.carouselVertical ? 'top' : 'left', offset );
             callback();
         };


### PR DESCRIPTION
Corrects erroneous behavior found in https://github.com/malsup/cycle2/issues/70 where slides lose their offset when wrapping from first to last or last to first.
