### PR TITLE
Better check for undefined value

### DIFF
--- a/jquery.cycle2.prevnext.js
+++ b/jquery.cycle2.prevnext.js
@@ -9,7 +9,7 @@ $.extend($.fn.cycle.defaults, {
     prev:           '> .cycle-prev',
     prevEvent:      'click.cycle',
     swipe:          false
-});    
+});
 
 $(document).on( 'cycle-initialized', function( e, opts ) {
     opts.API.getComponent( 'next' ).off( opts.nextEvent ).on( opts.nextEvent, function(e) {
@@ -42,7 +42,7 @@ $(document).on( 'cycle-update-view', function( e, opts, slideOpts, currSlide ) {
     var next = opts.API.getComponent( 'next' );
     var prev = opts.API.getComponent( 'prev' );
     var prevBoundry = opts._prevBoundry || 0;
-    var nextBoundry = opts._nextBoundry || opts.slideCount - 1;
+    var nextBoundry = (opts._nextBoundry !== undefined)?opts._nextBoundry:opts.slideCount - 1;
 
     if ( opts.currSlide == nextBoundry )
         next.addClass( cls ).prop( 'disabled', true );


### PR DESCRIPTION
Better check for undefined value, fixes right arrow showing when it shouldn't
Help when used with carousel plugin.
