### PR TITLE
removed style enforcement

### DIFF
--- a/jquery.tcycle.js
+++ b/jquery.tcycle.js
@@ -5,11 +5,15 @@ $.fn.tcycle = function(){
 
 return this.each(function(){
 	var f, i=0, c=$(this), s=c.children(), o=$.extend({speed:500,timeout:4000},c.data()),
-		l=s.length, w=c.width(), z=o.speed, t=o.timeout;
-	c.prepend($(s[0]).clone().css('visibility','hidden')).css({position:'relative',overflow:'hidden'});
+		l=s.length, w=c.width(), z=o.speed, t=o.timeout, css={overflow: 'hidden'},
+	    positioningRequired = function (e) {return ['absolute', 'fixed'].indexOf(e.css('position')) === -1;};
+	if (positioningRequired(c)) css.position = 'relative';
+	c.prepend($(s[0]).clone().css('visibility','hidden')).css(css);
 	f=o.fx!='scroll';
-	if(f)
-		s.css({position:'absolute',top:0,left:0}).hide().eq(0).show();
+	if (f) {
+	    css = positioningRequired(s) ? { position: 'absolute', top: 0, left: 0 } : {};
+	    s.css(css).hide().eq(0).show();
+	}
 	else
 		s.css({position:'absolute',top:0,left:w}).eq(0).css('left',0);
 	setTimeout(tx,t);


### PR DESCRIPTION
Made the container end element styling enforcement optional, in case it was already set to a tolerable value.

The use case I had was that the images inside the container were centered vertically and stretched to fit the container width. The container was absolutely positioned. So after running the bare plugin I needed to get rid of position: relative on a container (absolute behaves in the same way, not 100% sure about fixed, but from brief tests it looks like it does) and remove top: 0 and left: 0 from image styles (they were set in the css file)
