### PR TITLE
Items less than carouselvisible

### DIFF
--- a/jquery.cycle2.carousel.js
+++ b/jquery.cycle2.carousel.js
@@ -36,7 +36,11 @@ $.fn.cycle.transitions.carousel = {
         // issue #10
         for (var i=0; i < opts.startingSlide; i++) {
             opts.container.append( opts.slides[0] );
-        }        
+        }
+
+        if (opts.slideCount <= opts.carouselVisible)
+            opts._nextBoundry = 0;
+
     },
 
     // transition API impl

--- a/jquery.cycle2.carousel.js
+++ b/jquery.cycle2.carousel.js
@@ -43,8 +43,6 @@ $.fn.cycle.transitions.carousel = {
     postInit: function( opts ) {
         var i, j, slide, pagerCutoffIndex, wrap;
         var vert = opts.carouselVertical;
-        if (opts.carouselVisible && opts.carouselVisible > opts.slideCount)
-            opts.carouselVisible = opts.slideCount - 1;
         var visCount = opts.carouselVisible || opts.slides.length;
         var slideCSS = { display: vert ? 'block' : 'inline-block', position: 'static' };
 


### PR DESCRIPTION
Fixed issues raised by @ghost in #149 - line 46-47 didn't seem to be needed and was causing the visibility issues most noticeable if you use slides with custom content.
