### PR TITLE
Equality case in center plugin

### DIFF
--- a/jquery.cycle2.center.js
+++ b/jquery.cycle2.center.js
@@ -53,9 +53,9 @@ $(document).on( 'cycle-pre-initialize', function( e, opts ) {
         var contH = opts.container.height();
         var w = slide.width();
         var h = slide.height();
-        if (opts.centerHorz && w < contW)
+        if (opts.centerHorz && w <= contW)
             slide.css( 'marginLeft', (contW - w) / 2 );
-        if (opts.centerVert && h < contH)
+        if (opts.centerVert && h <= contH)
             slide.css( 'marginTop', (contH - h) / 2 );
     }
 });


### PR DESCRIPTION
When a margin has already been added, and the new slide width matches the container width (or height matches container height), the old margin needs to be set to zero, otherwise the slide will continue to have the margin, getting nudged out of the container.
