### PR TITLE
Added options autoHeightSpeed and autoHeightEasing

### DIFF
--- a/jquery.cycle2.autoheight.js
+++ b/jquery.cycle2.autoheight.js
@@ -110,8 +110,7 @@ function calcSentinelIndex( e, opts ) {
 
 function onBefore( e, opts, outgoing, incoming, forward ) {
     var h = $(incoming).outerHeight();
-    var duration = opts.sync ? opts.speed / 2 : opts.speed;
-    opts.container.animate( { height: h }, duration );
+    opts.container.animate( { height: h }, opts.autoHeightSpeed, opts.autoHeightEasing );
 }
 
 function onDestroy( e, opts ) {

--- a/jquery.cycle2.autoheight.js
+++ b/jquery.cycle2.autoheight.js
@@ -1,9 +1,11 @@
-/*! Cycle2 autoheight plugin; Copyright (c) M.Alsup, 2012; version: 20130304 */
+/*! Cycle2 autoheight plugin; Copyright (c) M.Alsup, 2012; version: 20130913 */
 (function($) {
 "use strict";
 
 $.extend($.fn.cycle.defaults, {
-    autoHeight: 0 // setting this option to false disables autoHeight logic
+    autoHeight: 0, // setting this option to false disables autoHeight logic
+    autoHeightSpeed: 250,
+    autoHeightEasing: null
 });    
 
 $(document).on( 'cycle-initialized', function( e, opts ) {


### PR DESCRIPTION
Added options autoHeightSpeed and autoHeightEasing to be used when autoHeight is set to "container".

autoHeightSpeed  - Speed of animation when changing slider height 
autoHeightEasing - Easing used when changing slider height

Usage example:
data-cycle-auto-height-easing="swing"
data-cycle-auto-height-speed="250"
