### PR TITLE
Measure slide's outerHeight and outerWidth instead of height and width for margin calcs in center plugin

### DIFF
--- a/jquery.cycle2.center.js
+++ b/jquery.cycle2.center.js
@@ -51,8 +51,8 @@ $(document).on( 'cycle-pre-initialize', function( e, opts ) {
         var slide = $(this);
         var contW = opts.container.width();
         var contH = opts.container.height();
-        var w = slide.width();
-        var h = slide.height();
+        var w = slide.outerWidth();
+        var h = slide.outerHeight();
         if (opts.centerHorz && w < contW)
             slide.css( 'marginLeft', (contW - w) / 2 );
         if (opts.centerVert && h < contH)

--- a/jquery.cycle2.center.js
+++ b/jquery.cycle2.center.js
@@ -53,9 +53,9 @@ $(document).on( 'cycle-pre-initialize', function( e, opts ) {
         var contH = opts.container.height();
         var w = slide.outerWidth();
         var h = slide.outerHeight();
-        if (opts.centerHorz && w < contW)
+        if (opts.centerHorz && w <= contW)
             slide.css( 'marginLeft', (contW - w) / 2 );
-        if (opts.centerVert && h < contH)
+        if (opts.centerVert && h <= contH)
             slide.css( 'marginTop', (contH - h) / 2 );
     }
 });


### PR DESCRIPTION
When a slide is a container using <a href="http://alistapart.com/article/creating-intrinsic-ratios-for-video">intrinsic ratios</a>, css height for the slide is zero, because all the visual height comes from padding. This wreaks havoc with vertical centering using the center plugin, unless padding is included in the calculation.
