### PR TITLE
Issue with disabled state on prev/next buttons when using a carrousel pager with a slideshow

### DIFF
--- a/jquery.cycle2.prevnext.js
+++ b/jquery.cycle2.prevnext.js
@@ -44,12 +44,12 @@ $(document).on( 'cycle-update-view', function( e, opts, slideOpts, currSlide ) {
     var prevBoundry = opts._prevBoundry || 0;
     var nextBoundry = (opts._nextBoundry !== undefined)?opts._nextBoundry:opts.slideCount - 1;
 
-    if ( opts.currSlide == nextBoundry )
+    if ( opts.currSlide >= nextBoundry )
         next.addClass( cls ).prop( 'disabled', true );
     else
         next.removeClass( cls ).prop( 'disabled', false );
 
-    if ( opts.currSlide === prevBoundry )
+    if ( opts.currSlide <= prevBoundry )
         prev.addClass( cls ).prop( 'disabled', true );
     else
         prev.removeClass( cls ).prop( 'disabled', false );


### PR DESCRIPTION
Hello there,

When using a carousel pager there is a bug with prev/next button losing their disabled state if the current slide slide is beyond the boundary slide.

It can be seen on the demo page:
http://jquery.malsup.com/cycle2/demo/caro-pager.php

The next button become disabled when the slide 4 is reached. But clicking on any pager slide beyond the fourth will remove the disabled state.

Here is the code adding/removing the disabled state/class to the buttons.

I have modified it by replacing "==" tests with ">=" and "<=" respectively.
Notice: the bug has been verified with the next button, I am not sure there is a bug with the prev button as my prev boundary is the first slide (index 0), there is nothing beyond this one.

This fix works for me but I am not sure if this is the correct way to fix it.
