### PR TITLE
Recognize wrapping in either direction on a API.next call.

### DIFF
--- a/jquery.cycle2.carousel.js
+++ b/jquery.cycle2.carousel.js
@@ -15,7 +15,8 @@ $( document ).on('cycle-bootstrap', function( e, opts, API ) {
     // override default 'next' function
     API.next = function() {
         var count = opts.reverse ? -1 : 1;
-        if ( opts.allowWrap === false && ( opts.currSlide + count ) > opts.slideCount - opts.carouselVisible )
+        var newCurrent = opts.currSlide + count;
+        if ( opts.allowWrap === false && (newCurrent < 0 || newCurrent > opts.slideCount - opts.carouselVisible ))
             return;
         opts.API.advanceSlide( count );
         opts.API.trigger('cycle-next', [ opts ]).log('cycle-next');


### PR DESCRIPTION
In API.next, when scrolling backwards (due to opts.reverse), must recognize wrapping before first the first slide to prevent issues.
