### PR TITLE
don't add margins if computed width of slide is zero

### DIFF
--- a/jquery.cycle2.center.js
+++ b/jquery.cycle2.center.js
@@ -53,10 +53,12 @@ $(document).on( 'cycle-pre-initialize', function( e, opts ) {
         var contH = opts.container.height();
         var w = slide.outerWidth();
         var h = slide.outerHeight();
-        if (opts.centerHorz && w <= contW)
-            slide.css( 'marginLeft', (contW - w) / 2 );
-        if (opts.centerVert && h <= contH)
-            slide.css( 'marginTop', (contH - h) / 2 );
+        if (w) {
+            if (opts.centerHorz && w <= contW)
+                slide.css( 'marginLeft', (contW - w) / 2 );
+            if (opts.centerVert && h <= contH)
+                slide.css( 'marginTop', (contH - h) / 2 );
+        }
     }
 });
 


### PR DESCRIPTION
If an img hasn't loaded yet, outerWidth() will return zero. The marginLeft in this case will be half the container width. This breaks layout pretty badly when the image loads after adjustSlide() has already run. Better to not apply margins in this case, and listen for img load in another way.
