### PR TITLE
Change random sort to use Fisher-Yates shuffle

### DIFF
--- a/src/jquery.cycle2.core.js
+++ b/src/jquery.cycle2.core.js
@@ -84,7 +84,17 @@ $.fn.cycle.API = {
         slides = slides.jquery ? slides : opts.container.find( slides );
 
         if ( opts.random ) {
-            slides.sort(function() {return Math.random() - 0.5;});
+            slides = (function(a) {  // Fisher-Yates shuffle
+                var i, j, t;
+                i = a.length;
+                while (--i > 0) {
+                    j = ~~(Math.random() * (i + 1));
+                    t = a[j];
+                    a[j] = a[i];
+                    a[i] = t;
+                }
+                return a;
+            })(slides);
         }
 
         opts.API.add( slides );


### PR DESCRIPTION
Sorting by Math.random() doesn't give you a fast or a consistent shuffle. With that said, this shuffle is still bigger and more complicated than the naive approach, and I haven't done any formal benchmarking or testing. I leave it completely to you.
