### PR TITLE
Fix for - Cycle2 YouTube Demo - Videos and Images not working

### DIFF
--- a/src/jquery.cycle2.video.js
+++ b/src/jquery.cycle2.video.js
@@ -6,7 +6,8 @@ var template = '<div class=cycle-youtube><object width="640" height="360">' +
     '<param name="movie" value="{{url}}"></param>' +
     '<param name="allowFullScreen" value="{{allowFullScreen}}"></param>' +
     '<param name="allowscriptaccess" value="always"></param>' +
-    '<embed src="{{url}}" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="{{allowFullScreen}}"></embed>' +
+    '<param name="wmode" value="opaque"></param>' +
+    '<embed src="{{url}}" type="application/x-shockwave-flash" allowscriptaccess="always" allowfullscreen="{{allowFullScreen}}" wmode="opaque"></embed>' +
 '</object></div>';
 
 $.extend($.fn.cycle.defaults, {

--- a/src/jquery.cycle2.video.js
+++ b/src/jquery.cycle2.video.js
@@ -25,7 +25,7 @@ $(document).on( 'cycle-bootstrap', function( e, opts ) {
 
     opts.container.find( opts.slides ).each(function(i) {
         // convert anchors to template markup
-        if ( !this.href )
+        if ( jQuery(this).attr('href') === undefined )
             return;
         var markup, slide = $(this), url = slide.attr( 'href' );
         var fs = opts.youtubeAllowFullScreen ? 'true' : 'false';


### PR DESCRIPTION
Fix for issue #285 

Needed to set wmode to opaque to fix z-index problem. For more info see: http://stackoverflow.com/questions/326196/ff3-windows-css-z-index-problem-with-youtube-player/326220#326220

Use jQuery to check if href is not undefined because old check failed in IE11.
