### PR TITLE
Use <button> for keyboard accessibility

### DIFF
--- a/src/jquery.cycle2.autoheight.js
+++ b/src/jquery.cycle2.autoheight.js
@@ -18,7 +18,6 @@ $(document).on( 'cycle-initialized', function( e, opts ) {
         return;
 
     // bind events
-    opts.container.on( 'cycle-slide-added cycle-slide-removed', initAutoHeight );
     opts.container.on( 'cycle-destroyed', onDestroy );
 
     if ( autoHeight == 'container' ) {
@@ -31,15 +30,15 @@ $(document).on( 'cycle-initialized', function( e, opts ) {
         opts._autoHeightRatio = ratio;
     }
 
-    // if autoHeight is a number then we don't need to recalculate the sentinel
-    // index on resize
+    // if autoHeight is calc or ratio then we need to recalculate the sentinel
+    // index on resize, and also on slide-added/slide-removed
     if ( t !== 'number' ) {
         // bind unique resize handler per slideshow (so it can be 'off-ed' in onDestroy)
         opts._autoHeightOnResize = function () {
             clearTimeout( resizeThrottle );
             resizeThrottle = setTimeout( onResize, 50 );
         };
-
+        opts.container.on( 'cycle-slide-added cycle-slide-removed', opts._autoHeightOnResize );
         $(window).on( 'resize orientationchange', opts._autoHeightOnResize );
     }
 

--- a/src/jquery.cycle2.pager.js
+++ b/src/jquery.cycle2.pager.js
@@ -7,7 +7,7 @@ $.extend($.fn.cycle.defaults, {
     pagerActiveClass: 'cycle-pager-active',
     pagerEvent:       'click.cycle',
     pagerEventBubble: undefined,
-    pagerTemplate:    '<span>&bull;</span>'
+    pagerTemplate:    '<button>&bull;</button>'
 });
 
 $(document).on( 'cycle-bootstrap', function( e, opts, API ) {


### PR DESCRIPTION
Great to have gotten away from <a href="#"> for the pager markup.
That's an accessibility anti-pattern. Anchor hrefs should only point to
external content, not a dummy placeholder.

But elements that have a more-or-less fixed role in loading in-page
content should really just be <button>s. This allows them to default to
conventional CSS focus outlines, and to be sequenced normally in the
tabindex for keyboard-only, non-mouse users. Buttons have much better
out-of-the-box accessibility for elements without ARIA roles:

http://yahoodevelopers.tumblr.com/post/59489724815/easy-fixes-to-common-
accessibility-problems

Also on a humourous, ranty note:

http://www.karlgroves.com/2013/05/14/links-are-not-buttons-neither-are-d
ivs-and-spans/

If you want to preserve the "bullet" look for the demos, you could maybe just make the buttons circular using CSS, and put some semantic visually hidden markup. {{slide#}}

P.S: I smiled to discover that Builtwith says that cycle (1 & 2 combined) is used on more than 3 million sites. More than Modernizr! Wow, congrats!
