### PR TITLE
Fixed fx for manual progressive slideshows

### DIFF
--- a/src/jquery.cycle2.progressive.js
+++ b/src/jquery.cycle2.progressive.js
@@ -94,7 +94,9 @@ $(document).on( 'cycle-pre-initialize', function( e, opts ) {
                 var slide = slides[ 0 ];
                 slides = slides.slice( 1 );
                 opts.container.one('cycle-slide-added', function(e, opts ) {
-                    nextFn.apply( opts.API );
+                    setTimeout(function () {
+                        nextFn.apply( opts.API );
+                    },50);
                     opts.container.removeClass('cycle-loading');
                 });
                 opts.container.addClass('cycle-loading');
@@ -115,7 +117,9 @@ $(document).on( 'cycle-pre-initialize', function( e, opts ) {
                 slides = slides.slice( 0, index );
                 opts.container.one('cycle-slide-added', function(e, opts ) {
                     opts.currSlide = 1;
-                    opts.API.advanceSlide( -1 );
+                    setTimeout(function () {
+                        opts.API.advanceSlide( -1 );
+                    },50);
                     opts.container.removeClass('cycle-loading');
                 });
                 opts.container.addClass('cycle-loading');


### PR DESCRIPTION
The Fx of my manual progressive slideshow wasn't working the way I expected. The fx started on the old slide (slide to left or fade-out) and then briefly the background was visible and then the fx started on the new slide. The slides weren't synchronized anymore. A small timeout fixed this issue.

You can see the bug in the demo of the progressive loading manual slide:
http://jquery.malsup.com/cycle2/demo/progressive.php#manual
