### PR TITLE
throttle recalc of sentinel on slide add/remove

### DIFF
--- a/src/jquery.cycle2.autoheight.js
+++ b/src/jquery.cycle2.autoheight.js
@@ -18,7 +18,6 @@ $(document).on( 'cycle-initialized', function( e, opts ) {
         return;
 
     // bind events
-    opts.container.on( 'cycle-slide-added cycle-slide-removed', initAutoHeight );
     opts.container.on( 'cycle-destroyed', onDestroy );
 
     if ( autoHeight == 'container' ) {
@@ -40,6 +39,7 @@ $(document).on( 'cycle-initialized', function( e, opts ) {
             resizeThrottle = setTimeout( onResize, 50 );
         };
 
+        opts.container.on( 'cycle-slide-added cycle-slide-removed', opts._autoHeightOnResize );
         $(window).on( 'resize orientationchange', opts._autoHeightOnResize );
     }
 


### PR DESCRIPTION
I had trouble with autoheight not working correctly when large batches of slides are added. It was tough to reproduce consistently, but I think I've tracked it down to this. If twenty slides are added all at once, initAutoHeight() should be throttled to only run once.
