### PR TITLE
fix rounding errors in responsive carousel

### DIFF
--- a/src/jquery.cycle2.carousel.js
+++ b/src/jquery.cycle2.carousel.js
@@ -143,7 +143,7 @@ $.fn.cycle.transitions.carousel = {
         var prepareDimensions = this.prepareDimensions;
 
         // throttle resize event
-        $(window).on( 'resize', resizeThrottle);
+        $(window).on( 'load resize', resizeThrottle);
 
         opts._carouselResizeThrottle = resizeThrottle;
         onResize();
@@ -156,7 +156,6 @@ $.fn.cycle.transitions.carousel = {
         function onResize() {
             opts._carouselWrap.stop( false, true );
             var slideWidth = opts.container.width() / opts.carouselVisible;
-            slideWidth = Math.ceil( slideWidth - adjustment );
             opts._carouselWrap.children().width( slideWidth );
             if ( opts._sentinel )
                 opts._sentinel.width( slideWidth );


### PR DESCRIPTION
Clipping the edge of a crucial slide in a responsive carousel looks really bad. This currently happens way too easily. Two fixes:

1) Browsers (incl Chrome) don't seem to resolve all rounding-related layout issues until load. Listen for that as well as resize.

2) Don't round slide CSS widths up to the nearest integer. This causes the last visible slide in the carousel to overflow the container. All modern browsers have used subpixel rendering for a while now. See column 4 in this chart:

http://cruft.io/posts/percentage-calculations-in-ie/
