### PR TITLE
Inline height calculated after cycle is destroyed

### DIFF
--- a/build/jquery.cycle2.js
+++ b/build/jquery.cycle2.js
@@ -741,6 +741,10 @@ $(document).on( 'cycle-initialized', function( e, opts ) {
 });
 
 function initAutoHeight( e, opts ) {
+    if (!opts._autoHeightOnResize) {
+        return;
+    }
+
     var clone, height, sentinelIndex;
     var autoHeight = opts.autoHeight;
 

--- a/build/jquery.cycle2.js
+++ b/build/jquery.cycle2.js
@@ -741,14 +741,10 @@ $(document).on( 'cycle-initialized', function( e, opts ) {
 });
 
 function initAutoHeight( e, opts ) {
-    if (!opts._autoHeightOnResize) {
-        return;
-    }
-
     var clone, height, sentinelIndex;
     var autoHeight = opts.autoHeight;
 
-    if ( autoHeight == 'container' ) {
+    if ( autoHeight == 'container' && opts._autoHeightRatio ) {
         height = $( opts.slides[ opts.currSlide ] ).outerHeight();
         opts.container.height( height );
     }


### PR DESCRIPTION
Initial state: There is a div (holder) with a child divs, each contains a table, holder div has no height.

For mobile size screen the cycle is initialized for holder with param {autoHeight: 'container'},
holder has inline height calculated, which is correct.
After resizing back to desktop size, cycle is destroyed, all atributes is cleared for holder, but
then some timer function is called and for holder div inline height is calculated again,
which is incorrect.
