### PR TITLE
Swipe Up / Down. Issue #726

### DIFF
--- a/src/jquery.cycle2.swipe.js
+++ b/src/jquery.cycle2.swipe.js
@@ -6,6 +6,11 @@
 // if you have jQuery Mobile installed, you do NOT need this script
 
 var supportTouch = 'ontouchend' in document;
+var swipeType;
+
+$(document).on( 'cycle-initialized', function( e, opts ) {
+    swipeType = opts.swipeType || 'horizontal';
+});
 
 $.event.special.swipe = $.event.special.swipe || {
     scrollSupressionThreshold: 10,   // More than this horizontal displacement, and we will suppress scrolling.
@@ -45,13 +50,18 @@ $.event.special.swipe = $.event.special.swipe || {
                 .one( 'touchend', function( event ) {
                     $this.unbind( 'touchmove', moveHandler );
 
-                    if ( start && stop ) {
-                        if ( stop.time - start.time < $.event.special.swipe.durationThreshold &&
+                    if ( start && stop && (stop.time - start.time < $.event.special.swipe.durationThreshold)) {
+                        if (swipeType == 'horizontal' && 
                                 Math.abs( start.coords[ 0 ] - stop.coords[ 0 ] ) > $.event.special.swipe.horizontalDistanceThreshold &&
-                                Math.abs( start.coords[ 1 ] - stop.coords[ 1 ] ) < $.event.special.swipe.verticalDistanceThreshold ) {
+                                Math.abs( start.coords[ 1 ] - stop.coords[ 1 ] ) < $.event.special.swipe.verticalDistanceThreshold) {
 
-                            start.origin.trigger( "swipe" )
-                                .trigger( start.coords[0] > stop.coords[ 0 ] ? "swipeleft" : "swiperight" );
+                                    start.origin.trigger( "swipe" )
+                                        .trigger( start.coords[0] > stop.coords[ 0 ] ? "swipeleft" : "swiperight" );
+                        } else if (Math.abs( start.coords[ 1 ] - stop.coords[ 1 ] ) > $.event.special.swipe.horizontalDistanceThreshold &&
+                                Math.abs( start.coords[ 0 ] - stop.coords[ 0 ] ) < $.event.special.swipe.verticalDistanceThreshold) {
+
+                                    start.origin.trigger( "swipe" )
+                                        .trigger( start.coords[1] > stop.coords[ 1 ] ? "swiperight" : "swipeleft" );
                         }
                     }
                     start = stop = undefined;


### PR DESCRIPTION
I have included the possibility of swipe up / down instead of just left / right. This is through cycle2 swipe plugin (jquery.cycle2.swipe).

For choose between swipe left/right or up/down you can use the option in the markup data-cycle-swipe-type="vertical" for up/down and, if not includes this option or it sets to "horizontal", the swipe will be left/right.

For set the animation movement up to down / down to up yo can use the cycle2 plugin scrollVert (jquery.cycle2.scrollVert) and set the option in markup data-cycle-swipe-fx="scrollVert".
