### PR TITLE
Scroll bug

### DIFF
--- a/src/jquery.cycle2.carousel.js
+++ b/src/jquery.cycle2.carousel.js
@@ -234,7 +234,7 @@ $.fn.cycle.transitions.carousel = {
         }
         else {
             for (i=currSlide; i > currSlide+hops; i--)
-                moveBy += this.getDim( opts, i, vert);
+                moveBy += this.getDim( opts, i-1, vert);
         }
         return moveBy;
     },


### PR DESCRIPTION
When carousels contain elements of different sizes, the scroll value is based on wrong elements. Only appears if scrolling back.
